### PR TITLE
Do not handle intents if we were told not to

### DIFF
--- a/rhasspyhomeassistant_hermes/__init__.py
+++ b/rhasspyhomeassistant_hermes/__init__.py
@@ -196,8 +196,9 @@ class HomeAssistantHermesMqtt(HermesClient):
     ) -> GeneratorType:
         """Received message from MQTT broker."""
         if isinstance(message, NluIntent):
-            async for intent_result in self.handle_intent(message):
-                yield intent_result
+            if self.handle_enabled:
+                async for intent_result in self.handle_intent(message):
+                    yield intent_result
         elif isinstance(message, HandleToggleOn):
             self.handle_enabled = True
             _LOGGER.debug("Intent handling enabled")


### PR DESCRIPTION
handle_enabled was being set, but it was not being used, so intents were handled even if the "Handle" checkbox in the UI was not checked.