### PR TITLE
Add '_side_id' meta slot to intent

### DIFF
--- a/rhasspyhomeassistant_hermes/__init__.py
+++ b/rhasspyhomeassistant_hermes/__init__.py
@@ -151,6 +151,7 @@ class HomeAssistantHermesMqtt(HermesClient):
             slots["_text"] = nlu_intent.input
             slots["_raw_text"] = nlu_intent.raw_input
             slots["_intent"] = nlu_intent.to_dict()
+            slots["_site_id"] = nlu_intent.site_id
 
             hass_intent = {"name": nlu_intent.intent.intent_name, "data": slots}
 


### PR DESCRIPTION
In my opinion sending the `sideId` to Home Assistant as a meta slot is very useful. This way actions can be executed in the same area where the intent was triggered. It allows to e.g. say *Turn on the lights* to either turn on the living room or bedroom lights, depending on where you are.

I'm not sure if the meta slot should be called `_side_id` to follow the scheme used by the other meta slots or if it should be called `side_id` to be compatible with Snips. What do you think?

This solves https://github.com/rhasspy/rhasspy-homeassistant-hermes/issues/2.