### PR TITLE
Read token from supervisor

### DIFF
--- a/rhasspyhomeassistant_hermes/__init__.py
+++ b/rhasspyhomeassistant_hermes/__init__.py
@@ -182,7 +182,7 @@ class HomeAssistantHermesMqtt(HermesClient):
         if self.api_password:
             return {"X-HA-Access": self.api_password}
 
-        hassio_token = os.environ.get("HASSIO_TOKEN")
+        hassio_token = os.getenv("HASSIO_TOKEN") or os.getenv("SUPERVISOR_TOKEN")
         if hassio_token:
             return {"Authorization": f"Bearer {hassio_token}"}
 


### PR DESCRIPTION
The `SUPERVISOR_TOKEN` environment variable is defined when running in a
Home Assistant Add-On:
https://developers.home-assistant.io/docs/add-ons/communication/